### PR TITLE
Add device tracker for vehicle location

### DIFF
--- a/custom_components/enode/__init__.py
+++ b/custom_components/enode/__init__.py
@@ -13,6 +13,7 @@ from .views import EnodeWebhookView
 _PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.DEVICE_TRACKER,
     Platform.GEO_LOCATION,
     Platform.SENSOR,
     Platform.SWITCH,

--- a/custom_components/enode/translations/en.json
+++ b/custom_components/enode/translations/en.json
@@ -152,6 +152,11 @@
         "name": "Refresh Data"
       }
     },
+    "device_tracker": {
+      "location": {
+        "name": "Location"
+      }
+    },
     "geo_location": {
       "location": {
         "name": "Location",


### PR DESCRIPTION
Introduce a device tracker entity for vehicles, enabling location tracking within the Enode integration. This addition includes the setup for generating vehicle trackers and their associated attributes. The Geo Location entity is now disabled by default.